### PR TITLE
Adding wait-for-it-listen.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ $ echo $?
 
 ## Thanks
 
-I wrote this script for my employer, [Ginkgo Bioworks](http://www.ginkgobioworks.com/), who was kind enough to let me release it as an open source tool.  We are always looking to hire talented folks who are interested in working in the field of synthetic biology.
+I wrote this script for my employer, [Ginkgo Bioworks](http://www.ginkgobioworks.com/), who was kind enough to let me release it as an open source tool.  We are always looking to [hire](https://jobs.lever.co/ginkgobioworks) talented folks who are interested in working in the field of synthetic biology.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# HELP NEEDED
+
+Hi there!  I wrote `wait-for-it` in order to help me orchestrate containers I operate at my day job.  I thought it was a neat little script, so I published it.  I assumed I would be its only user, but that's not what happened!  `wait-for-it` has received more stars then all of my other public repositories put together.  I had no idea this tool would solict such an audience, and I was equally unprepared to carve out the time required to address my user's issues and patches.  I've been thinking a lot about how I want to handle this, and I've decided that I would like to solicit a volunteer from the community who would be willing to be a co-maintainer of this repository.  If this is something you might be interested in, please email me at `waitforit@polymerase.org`.  Thanks!
+
+## wait-for-it
+
 `wait-for-it.sh` is a pure bash script that will wait on the availability of a host and TCP port.  It is useful for synchronizing the spin-up of interdependent services, such as linked docker containers.  Since it is a pure bash script, it does not have any external dependencies.
 
 ## Usage
@@ -57,3 +63,7 @@ wait-for-it.sh: timeout occurred after waiting 15 seconds for www.google.com:81
 $ echo $?
 124
 ```
+
+## Thanks
+
+I wrote this script for my employer, [Ginkgo Bioworks](http://www.ginkgobioworks.com/), who was kind enough to let me release it as an open source tool.  We are always looking to hire talented folks who are interested in working in the field of synthetic biology.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # HELP NEEDED
 
+### March 13, 2017 update
+
+Since I posted this request for help, I've had a dozen or so responses which I am now sorting through.  Applicants are filling out a google form to help me pick the best volunteer for this project.  I have set a deadline of Match 17th for survey submissions, and will select a volunteer on March 19th.  Once this is done, and the repo is configured, we will tagteam through the backlog of issues amd pull requests.  I realized it's been frustrating, and many different forks of this project have sprung up.  I think that's awesome, and I look forward to working and consolidating the various enhancements.  If you are interested in helping, please fill out this (survey)[https://goo.gl/forms/GKCBFxaloaU47aky1] no later then March 17th.  Thanks!
+
+### Old request follows:
+
 Hi there!  I wrote `wait-for-it` in order to help me orchestrate containers I operate at my day job.  I thought it was a neat little script, so I published it.  I assumed I would be its only user, but that's not what happened!  `wait-for-it` has received more stars then all of my other public repositories put together.  I had no idea this tool would solicit such an audience, and I was equally unprepared to carve out the time required to address my user's issues and patches.  I would like to solicit a volunteer from the community who would be willing to be a co-maintainer of this repository.  If this is something you might be interested in, please email me at `waitforit@polymerase.org`.  Thanks!
 
 ## wait-for-it

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### March 13, 2017 update
 
-Since I posted this request for help, I've had a dozen or so responses which I am now sorting through.  Applicants need to fill out [this](https://goo.gl/forms/GKCBFxaloaU47aky1) survey by March 17th.  I will select, notify and announce the new volunteer(s) on March 19th.  Once this is done, me and my team will work through the backlog of issues amd pull requests.  Thank you for your paitence, more updates to come as scheduled.
+Since I posted this request for help, I've had a dozen or so responses which I am now sorting through.  Applicants need to fill out [this](https://goo.gl/forms/GKCBFxaloaU47aky1) survey by March 17th.  I will select, notify and announce the new volunteer(s) on March 19th.  Once this is done, me and my team will work through the backlog of issues amd pull requests.  Thanks for your paitence.
 
 ### Old request follows:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### March 13, 2017 update
 
-Since I posted this request for help, I've had a dozen or so responses which I am now sorting through.  Applicants are filling out a google form to help me pick the best volunteer for this project.  I have set a deadline of Match 17th for survey submissions, and will select a volunteer on March 19th.  Once this is done, and the repo is configured, we will tagteam through the backlog of issues amd pull requests.  I realized it's been frustrating, and many different forks of this project have sprung up.  I think that's awesome, and I look forward to working and consolidating the various enhancements.  If you are interested in helping, please fill out this (survey)[https://goo.gl/forms/GKCBFxaloaU47aky1] no later then March 17th.  Thanks!
+Since I posted this request for help, I've had a dozen or so responses which I am now sorting through.  Applicants are filling out a google form to help me pick the best volunteer for this project.  I have set a deadline of Match 17th for survey submissions, and will select a volunteer on March 19th.  Once this is done, and the repo is configured, we will tagteam through the backlog of issues amd pull requests.  I realized it's been frustrating, and many different forks of this project have sprung up.  I think that's awesome, and I look forward to working and consolidating the various enhancements.  If you are interested in helping, please fill out this [survey](https://goo.gl/forms/GKCBFxaloaU47aky1) no later then March 17th.  Thanks!
 
 ### Old request follows:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HELP NEEDED
 
-Hi there!  I wrote `wait-for-it` in order to help me orchestrate containers I operate at my day job.  I thought it was a neat little script, so I published it.  I assumed I would be its only user, but that's not what happened!  `wait-for-it` has received more stars then all of my other public repositories put together.  I had no idea this tool would solict such an audience, and I was equally unprepared to carve out the time required to address my user's issues and patches.  I've been thinking a lot about how I want to handle this, and I've decided that I would like to solicit a volunteer from the community who would be willing to be a co-maintainer of this repository.  If this is something you might be interested in, please email me at `waitforit@polymerase.org`.  Thanks!
+Hi there!  I wrote `wait-for-it` in order to help me orchestrate containers I operate at my day job.  I thought it was a neat little script, so I published it.  I assumed I would be its only user, but that's not what happened!  `wait-for-it` has received more stars then all of my other public repositories put together.  I had no idea this tool would solicit such an audience, and I was equally unprepared to carve out the time required to address my user's issues and patches.  I would like to solicit a volunteer from the community who would be willing to be a co-maintainer of this repository.  If this is something you might be interested in, please email me at `waitforit@polymerase.org`.  Thanks!
 
 ## wait-for-it
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### March 13, 2017 update
 
-Since I posted this request for help, I've had a dozen or so responses which I am now sorting through.  Applicants are filling out a google form to help me pick the best volunteer for this project.  I have set a deadline of Match 17th for survey submissions, and will select a volunteer on March 19th.  Once this is done, and the repo is configured, we will tagteam through the backlog of issues amd pull requests.  I realized it's been frustrating, and many different forks of this project have sprung up.  I think that's awesome, and I look forward to working and consolidating the various enhancements.  If you are interested in helping, please fill out this [survey](https://goo.gl/forms/GKCBFxaloaU47aky1) no later then March 17th.  Thanks!
+Since I posted this request for help, I've had a dozen or so responses which I am now sorting through.  Applicants need to fill out [this](https://goo.gl/forms/GKCBFxaloaU47aky1) survey by March 17th.  I will select, notify and announce the new volunteer(s) on March 19th.  Once this is done, me and my team will work through the backlog of issues amd pull requests.  Thank you for your paitence, more updates to come as scheduled.
 
 ### Old request follows:
 

--- a/wait-for-it-listen.sh
+++ b/wait-for-it-listen.sh
@@ -1,0 +1,182 @@
+#!/bin/sh
+#   Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        if [[ $ISBUSY -eq 1 ]]; then
+            nc -l -v -s $HOST -p $PORT
+            result=$?
+        else
+            (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+            result=$?
+        fi
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $BUSYTIMEFLAG $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:)
+        hostport=${1/:/}
+        HOST=${hostport}
+        #PORT=${hostport[2]}
+        shift 1
+        ;;
+        :*)
+        hostport=${1/:/}
+        PORT=${hostport}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI="$@"
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+# check to see if timeout is from busybox?
+# check to see if timeout is from busybox?
+TIMEOUT_PATH=$(realpath $(which timeout))
+if [[ $TIMEOUT_PATH == "busybox" ]]; then
+        ISBUSY=0
+        BUSYTIMEFLAG=""
+else
+        ISBUSY=1
+        BUSYTIMEFLAG="-t"
+fi
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec $CLI
+else
+    exit $RESULT
+fi


### PR DESCRIPTION
This reverses the control of the wait-for-it script to some extent: the script listens on a port and waits for another container to finish it's init process and scan that port. I found a use case where a port being reachable did not equate to that container being 'ready' when I was initializing a DB from a SQL dump file in postgres.
